### PR TITLE
ID-kaardi kastikese kirjeldus laiemaks

### DIFF
--- a/disain/index.html
+++ b/disain/index.html
@@ -77,9 +77,9 @@
         <div id="collapseOne" class="collapse" role="tabpanel" aria-labelledby="methodIDCard" aria-expanded="false">
           <div class="block-hr hidden-xs"></div>
           <div class="white hidden-xs method-block-collapsible">
+             <p>Sisesta kaart lugejasse ja vajuta "Sisene"</p>
             <div class="row">
               <div class="col-md-6 col-sm-6 col-xs-6">
-                <p>Sisesta kaart lugejasse ja vajuta "Sisene"</p>
                 <button class="primary" type="button" name="button">Sisene</button>
               </div>
               <div class="col-md-6 col-sm-6 col-xs-6">


### PR DESCRIPTION
Kirjelduse tekst oli jäetud vale kolumni sisse, mis oli poole kitsam. Seetõttu ilmus ka tekst poole kitsamalt kui alumises autentimiskastikeses. Sarnaselt alumisega tõstsin kirjelduse paragrahvi kolumnist välja method-block-collapsible div'i sisse, mis teeb teksti õige laiuseks.